### PR TITLE
fix : 도커파일 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-#FROM --platform=linux/amd64 gradle:8.10.2-jdk21 AS builder
-#FROM gradle:8.14.2-jdk17 AS builder
+# 1단계: Builder stage
 FROM gradle:8.14.2-jdk21 AS builder
+
+ENV GRADLE_USER_HOME=/tmp/.gradle
+ENV KOTLIN_COMPILER_HOME=/tmp/.kotlin
+
 WORKDIR /app
 COPY . .
+
 RUN chmod +x ./gradlew
 RUN ls -la
 RUN ./gradlew --version
@@ -10,7 +14,9 @@ RUN ./gradlew clean bootJar --no-daemon
 
 # 2단계: Runtime stage
 FROM eclipse-temurin:21-jre
+
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
+
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
# 이슈내용
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/41888fd4-94f7-44dd-9e50-4589ef77bae3" />
build success 이후 빌드 실패

# 이슈 원인
Gradle 빌드가 끝나면서 .kotlin/daemon/*.run 파일이 사라졌는데, Kaniko가 그걸 이미지로 찍으려다 실패한 것으로 추정

# 해결 방안
코틀린 경로를 환경변수화